### PR TITLE
Add support for messages already base64 encoded

### DIFF
--- a/lib/actions/send.js
+++ b/lib/actions/send.js
@@ -33,6 +33,8 @@ function processAction(msg, cfg) {
 
     function getData() {
         console.log('enter sendSMS');
+        const IS_BASE64_REGEX = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/;
+
         const AppId = process.env.AppId || cfg.AppId;
         const AppSec = process.env.AppSec || cfg.AppSec;
         const PmiKey = process.env.PmiKey || cfg.pmiKey;
@@ -40,7 +42,8 @@ function processAction(msg, cfg) {
         const SMSUri = process.env.SMSUri || cfg.SMSUri;
 
         const Msisdn = msg.body.msisdn;
-        const SMSMsg = new Buffer(msg.body.text).toString('base64');
+
+        const SMSMsg = IS_BASE64_REGEX.test(msg.body.text) ? msg.body.text : new Buffer(msg.body.text).toString('base64');
 
         console.log(`Msisdn=${Msisdn}`);
         console.log(`guid=${GuId}`);


### PR DESCRIPTION
In some cases the system may want to send messages which have already been base64 encoded by another stage of the flow or an external provider.

In order to avoid duplicate encoding a check is now included and the message is either pass thru or base64 encoded.