### PR TITLE
Make Originator Configurable

### DIFF
--- a/component.json
+++ b/component.json
@@ -15,6 +15,12 @@
         "required": true,
         "viewClass": "TextFieldWithNoteView",
         "note": "Please enter your PMI key!"
+      },
+      "originator": {
+        "label":"Originator",
+        "required": false,
+        "viewClass": "TextFieldWithNoteView",
+        "note": "Enter an optional originator"
       }
     }
   },

--- a/lib/actions/send.js
+++ b/lib/actions/send.js
@@ -57,7 +57,7 @@ function processAction(msg, cfg) {
             <originator xsi:type="xsd:string">${Originator}</originator>` : '';
 
         const soapMsg = `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema.dtd" 
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:tom="http://planb.de/TOMessage" 
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">

--- a/lib/actions/send.js
+++ b/lib/actions/send.js
@@ -40,6 +40,7 @@ function processAction(msg, cfg) {
         const PmiKey = process.env.PmiKey || cfg.pmiKey;
         const GuId = process.env.GuId || cfg.guid;
         const SMSUri = process.env.SMSUri || cfg.SMSUri;
+        const Originator = process.env.Originator || cfg.originator || null;
 
         const Msisdn = msg.body.msisdn;
 
@@ -50,9 +51,13 @@ function processAction(msg, cfg) {
         console.log(`pmiKey=${PmiKey}`)
         console.log(`Text=${msg.body.text}`);
         console.log(`Msg=${SMSMsg}`);
+        console.log(`Originator=${Originator}`);
+
+        const OriginatorTag = Originator ? `
+            <originator xsi:type="xsd:string">${Originator}</originator>` : '';
 
         const soapMsg = `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema.dtd" 
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:tom="http://planb.de/TOMessage" 
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
@@ -68,7 +73,7 @@ function processAction(msg, cfg) {
             <eventdescription xsi:type="xsd:string">SMS-GW</eventdescription>
         </accounting_data>
         <message_data xsi:type="tom:MessageData" 
-            xmlns:tom="http://planb.de/TOMessage-Schema">
+            xmlns:tom="http://planb.de/TOMessage-Schema">${OriginatorTag}
             <msisdn xsi:type="xsd:string">${Msisdn}</msisdn>
             <!--Zero or more repetitions:-->
             <item xsi:type="xsd:string">1</item>

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -13,6 +13,7 @@
                 "PmiKey": "{{xmsgwPmiKey}}",
                 "GuId": "{{xmsgwGuId}}",
                 "SMSUri": "{{xmsgwSMSUri}}"
+                "originator": "{{xmsgwOriginator}}"
             }
         }
     }


### PR DESCRIPTION
In order to make the originator optionally configurable to a telephone number or an arbitrary string I have extended the configuration and made the xml construct optionally extensible with the value required. 